### PR TITLE
Fix/visualisation

### DIFF
--- a/src/OrthoTree/OrthoTree.hpp
+++ b/src/OrthoTree/OrthoTree.hpp
@@ -69,8 +69,6 @@ namespace ippl {
         Kokkos::View<morton_code*> tree_view("tree_view_naive", result_tree.size());
         tree_view.assign_data(result_tree.data());
 
-        octants_to_file(tree_view);
-
         return tree_view;
     }
 

--- a/src/OrthoTree/helpers/AidList.h
+++ b/src/OrthoTree/helpers/AidList.h
@@ -66,8 +66,8 @@ namespace ippl {
          */
         size_t getUpperBoundIndexExclusive(morton_code octant) const;
 
-        template <typename Iterator>
-        Kokkos::vector<size_t> getNumParticlesInOctantsParalell(Iterator begin, Iterator end);
+        template <typename Container>
+        Kokkos::vector<size_t> getNumParticlesInOctantsParalell(const Container& container);
 
         /**
          * @brief Returns the highest index s.t. octants(index-1) <= octant <= octants(index)

--- a/src/OrthoTree/helpers/AidList.hpp
+++ b/src/OrthoTree/helpers/AidList.hpp
@@ -198,9 +198,9 @@ namespace ippl {
     }
 
     template <size_t Dim>
-    template <typename Iterator>
-    Kokkos::vector<size_t> AidList<Dim>::getNumParticlesInOctantsParalell(Iterator begin,
-                                                                          Iterator end) {
+    template <typename Container>
+    Kokkos::vector<size_t> AidList<Dim>::getNumParticlesInOctantsParalell(
+        const Container& container) {
         size_t size_buff;
 
         Kokkos::vector<size_t> weights;
@@ -221,14 +221,14 @@ namespace ippl {
             }
 
             weights.clear();
-            for (auto it = begin; it != end; ++it) {
+            for (auto it = container.data(); it != container.data() + container.size(); ++it) {
                 weights.push_back(getNumParticlesInOctant(*it));
             }
 
         } else {
-            size_buff = static_cast<size_t>(end - begin);
+            size_buff = container.size();
             Comm->send(size_buff, 1, 0, 0);
-            Comm->send(*begin, size_buff, 0, 0);
+            Comm->send(*container.data(), size_buff, 0, 0);
             weights.resize(size_buff);
             mpi::Status weights_status;
             Comm->recv(weights.data(), size_buff, 0, 0, weights_status);

--- a/src/OrthoTree/helpers/AidList.hpp
+++ b/src/OrthoTree/helpers/AidList.hpp
@@ -146,7 +146,7 @@ namespace ippl {
             });
 
             const size_t start = 0;
-            const size_t end   = batch_size + 1;  // one extra octant
+            const size_t end   = batch_size + (0 < remainder ? 1 : 0);  // one extra octant
 
             min_max_octants[0] = getOctant(start);
             min_max_octants[1] = getOctant(end - 1);

--- a/src/OrthoTree/helpers/AidList.hpp
+++ b/src/OrthoTree/helpers/AidList.hpp
@@ -127,28 +127,26 @@ namespace ippl {
         if (world_rank == 0) {
             const size_t size       = this->size();
             const size_t batch_size = size / world_size;
-            const size_t remainder  = (size % batch_size) + batch_size;
+            const size_t remainder  = size % world_size;
 
             // rank_{i+1} = [ (i * batch_size) + remainder, (i+1) * batch_size ]
             Kokkos::parallel_for("Send min/max octants", world_size - 1, [=, this](const size_t i) {
-                morton_code
-                    local_min_max_octants[2];  // inside the parallel for because of read-only
-                const size_t start = (i * batch_size) + remainder;
+                morton_code local_min_max_octants[2] = {0};  // inside the parallel for because of
+                                                             // read-only
+                const size_t target_rank = i + 1;
+
+                // distribute the remainders for a more balanced load
+                const size_t start = (target_rank * batch_size) + (target_rank < remainder ? 1 : 0);
                 const size_t end   = start + batch_size;
 
                 local_min_max_octants[0] = getOctant(start);
                 local_min_max_octants[1] = getOctant(end - 1);
 
-                // send to rank + 1, as parallel_for starts at index=0
-                const size_t target_rank = i + 1;
                 Comm->send(*local_min_max_octants, 2, target_rank, 0);
             });
 
-            // assign min/max for rank 0
-            // rank_0 = [ (#ranks - 1) * batch_size, #octants ]
-
             const size_t start = 0;
-            const size_t end   = start + remainder;
+            const size_t end   = batch_size + 1;  // one extra octant
 
             min_max_octants[0] = getOctant(start);
             min_max_octants[1] = getOctant(end - 1);

--- a/src/OrthoTree/paralell_construction/algo01.hpp
+++ b/src/OrthoTree/paralell_construction/algo01.hpp
@@ -126,10 +126,7 @@ namespace ippl {
             for (const auto& child_octant : morton_helper.get_children(octant)) {
                 const size_t count = this->aid_list_m.getNumParticlesInOctant(child_octant);
 
-                // no need to push in this case
-                if (count > 0) {
-                    s.push({child_octant, count});
-                }
+                s.push({child_octant, count});
             }
         }
 

--- a/src/OrthoTree/paralell_construction/algo01.hpp
+++ b/src/OrthoTree/paralell_construction/algo01.hpp
@@ -31,8 +31,6 @@ namespace ippl {
         for (size_t i = 0; i < tree_view.size(); ++i) {
             auto num_particles = this->aid_list_m.getNumParticlesInOctant(tree_view[i]);
             total_particles += num_particles;
-
-            logger << "Adding: " << num_particles << " particles" << endl;
         }
 
         size_t global_total_particles = 0;

--- a/src/OrthoTree/paralell_construction/algo01.hpp
+++ b/src/OrthoTree/paralell_construction/algo01.hpp
@@ -17,7 +17,6 @@ namespace ippl {
         auto [min_octant, max_octant] = this->aid_list_m.getMinReqOctants();
 
         auto octants = block_partition(min_octant, max_octant);
-        this->aid_list_m.innitFromOctants(octants.front(), octants.back());
 
         particles_to_file(particles);
 

--- a/src/OrthoTree/paralell_construction/algo04.hpp
+++ b/src/OrthoTree/paralell_construction/algo04.hpp
@@ -38,8 +38,7 @@ namespace ippl {
 
         Kokkos::vector<morton_code> G = complete_tree(C);
 
-        Kokkos::vector<size_t> weights =
-            this->aid_list_m.getNumParticlesInOctantsParalell(G.begin(), G.end());
+        Kokkos::vector<size_t> weights = this->aid_list_m.getNumParticlesInOctantsParalell(G);
 
         auto octants = partition(G, weights);
 

--- a/src/OrthoTree/paralell_construction/algo04.hpp
+++ b/src/OrthoTree/paralell_construction/algo04.hpp
@@ -36,44 +36,16 @@ namespace ippl {
             }
         }
 
-        logger << "C.size()=" << C.size() << endl;
         Kokkos::vector<morton_code> G = complete_tree(C);
-        logger << "we now have n_octants = " << G.size() << endl;
 
         Kokkos::vector<size_t> weights =
             this->aid_list_m.getNumParticlesInOctantsParalell(G.begin(), G.end());
-        logger << "weights have size: " << weights.size() << endl;
-        /*
-        for (size_t i = 0; i < G.size(); ++i) {
-            morton_code base_tree_octant = G[i];
-            weights[i]                   = std::count_if(
-                starting_octants.begin(), starting_octants.end(),
-                [&base_tree_octant, this](const morton_code& unpartitioned_tree_octant) {
-                    return (unpartitioned_tree_octant == base_tree_octant)
-                           || (morton_helper.is_descendant(unpartitioned_tree_octant,
-                                                                             base_tree_octant));
-                });
-        }
-        */
 
-        auto partitioned_tree = partition(G, weights);
-        // TODO: THIS MIGHT BE WRONG? this is not needed, we sync the aid list outside of this
-        /*
-        Kokkos::vector<morton_code> global_unpartitioned_tree;
-        global_unpartitioned_tree.push_back(min_octant);
-        global_unpartitioned_tree.push_back(max_octant);
-        starting_octants.clear();
-        for (morton_code gup_octant : global_unpartitioned_tree) {
-            for (const morton_code& p_octant : partitioned_tree) {
-                if (gup_octant == p_octant || morton_helper.is_descendant(gup_octant, p_octant)) {
-                    starting_octants.push_back(gup_octant);
-                    break;
-                }
-            }
-        }
-*/
-        logger << "finished, partitioned_tree.size() = " << partitioned_tree.size() << endl;
+        auto octants = partition(G, weights);
+
+        this->aid_list_m.innitFromOctants(octants.front(), octants.back());
+
         END_FUNC;
-        return partitioned_tree;
+        return octants;
     }
 }  // namespace ippl

--- a/src/OrthoTree/scripts/visualise.sh
+++ b/src/OrthoTree/scripts/visualise.sh
@@ -10,7 +10,13 @@ fi
 NUM_PROCESSORS=$1
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-mkdir -p "$SCRIPT_DIR/output"
+
+# Ensure the output folder exists and clear its contents
+if [ -d "$SCRIPT_DIR/output" ]; then
+    rm -rf "$SCRIPT_DIR/output"/*
+else
+    mkdir -p "$SCRIPT_DIR/output"
+fi
 
 # Step 2: Run the experiment script
 echo "Running the experiment with $NUM_PROCESSORS processors..."

--- a/unit_tests/OrthoTree/helpers/aid_list.cpp
+++ b/unit_tests/OrthoTree/helpers/aid_list.cpp
@@ -338,13 +338,13 @@ TEST(AidListTest, GetReqOctantsTest) {
                                       << ": " << min_octant << " != " << max_octant;
 
     if (Comm->rank() == 0) {
-        EXPECT_EQ(min_octant, 0b001);
+        EXPECT_EQ(min_octant, 0b001) << "Rank 0 expected: " << 0b001 << ", but got: " << min_octant;
     } else if (Comm->rank() == 1) {
-        EXPECT_EQ(min_octant, 0b011);
+        EXPECT_EQ(min_octant, 0b011) << "Rank 1 expected: " << 0b011 << ", but got: " << min_octant;
     } else if (Comm->rank() == 2) {
-        EXPECT_EQ(min_octant, 0b101);
+        EXPECT_EQ(min_octant, 0b101) << "Rank 2 expected: " << 0b101 << ", but got: " << min_octant;
     } else if (Comm->rank() == 3) {
-        EXPECT_EQ(min_octant, 0b111);
+        EXPECT_EQ(min_octant, 0b111) << "Rank 3 expected: " << 0b111 << ", but got: " << min_octant;
     }
 }
 

--- a/unit_tests/OrthoTree/helpers/aid_list.cpp
+++ b/unit_tests/OrthoTree/helpers/aid_list.cpp
@@ -332,20 +332,16 @@ TEST(AidListTest, GetReqOctantsTest) {
 
     auto [min_octant, max_octant] = aid_list.getMinReqOctants();
 
-    // expected to be equivalent, as the list is initialised with 4 different octants
-    // n_particles_per_proc times
-    EXPECT_EQ(min_octant, max_octant) << "Failed min_octant == max_octant on Rank" << Comm->rank()
-                                      << ": " << min_octant << " != " << max_octant;
+    ASSERT_EQ(min_octant, max_octant)
+        << "Rank: " << Comm->rank() << " got min: " << min_octant << ", max: " << max_octant;
 
-    if (Comm->rank() == 0) {
-        EXPECT_EQ(min_octant, 0b001) << "Rank 0 expected: " << 0b001 << ", but got: " << min_octant;
-    } else if (Comm->rank() == 1) {
-        EXPECT_EQ(min_octant, 0b011) << "Rank 1 expected: " << 0b011 << ", but got: " << min_octant;
-    } else if (Comm->rank() == 2) {
-        EXPECT_EQ(min_octant, 0b101) << "Rank 2 expected: " << 0b101 << ", but got: " << min_octant;
-    } else if (Comm->rank() == 3) {
-        EXPECT_EQ(min_octant, 0b111) << "Rank 3 expected: " << 0b111 << ", but got: " << min_octant;
-    }
+    morton_code base_octant = 1;
+    morton_code step_size   = 2;
+
+    morton_code expected_octant = base_octant + (Comm->rank() * step_size);
+    EXPECT_EQ(min_octant, expected_octant)
+        << "Rank " << Comm->rank() << " expected: " << expected_octant
+        << ", but got: " << min_octant;
 }
 
 /**


### PR DESCRIPTION
I only wanted to fix the visualisation on this branch but i got carried away slightly.

1. Visualisation is now correct, the issue was that we discarded octants with zero particles in it while constructing the tree. This way we only kept octants that actually include particles.
2. The aid list now distributes the remaining particles as evenly as possible, meaning ranks only differ in $\pm 1$ particle (only in the initial distribution)
3. Moved the AidList initialisation from algorithm 1 into algorithm 4. I did this because it is needed again in algorithm 11. Now that im writing this, im not so sure anymore... Algo 11 probably only replaces the last part of algo 1? Anyway, plz merge thx